### PR TITLE
Tree shaked icon import, bundle size lower

### DIFF
--- a/src/AddressAutocomplete.tsx
+++ b/src/AddressAutocomplete.tsx
@@ -1,4 +1,4 @@
-import { LocationOn } from '@mui/icons-material';
+import LocationOn from '@mui/icons-material/LocationOn';
 import { Autocomplete, AutocompleteChangeReason, AutocompleteProps, AutocompleteRenderInputParams, Box, Grid, TextField, Typography } from '@mui/material';
 import parse from 'autosuggest-highlight/parse';
 import throttle from 'lodash.throttle';


### PR DESCRIPTION
Without tree shaking, bundle size is over 4mb because mui icons-material imports all icons. This should fix it.